### PR TITLE
main: list metrics in various formats

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,21 +18,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var (
-	help = flag.Bool("h", false, "Display help and exit")
-	list = flag.Bool("l", false, "List all supported metrics and exit")
-)
+var format = flag.String("l", "",
+	"List all supported metrics in the specified format and exit.\n"+
+		"Supported formats are: text, json, csv, tsv, markdown.")
 
 func main() {
 	flag.Parse()
-	switch {
-	case *help:
-		flag.Usage()
-		os.Exit(0)
-	case *list:
-		for _, c := range collectors.Collectors() {
-			lib.PrintMetrics(c)
-		}
+	if *format != "" {
+		lib.PrintMetrics(collectors.Collectors(), *format)
 		os.Exit(0)
 	}
 	if err := config.Parse(); err != nil {


### PR DESCRIPTION
Change the -l flag to accept a format argument that changes the printed metrics format. Implement these formats: text, json, csv, tsv, markdown.

Here are a couple of (text truncated because too long for github) examples:

<details>

<summary>
`$ ./dataplane-node-exporter -l csv | column -t -s ';'`
</summary>

```console
METRIC                                                   COLLECTOR  SET       TYPE     LABELS                               HELP                                                                                            
ovs_bridge_port_count                                    bridge     base      gauge    bridge,datapath_type                 The number of ports in a bridge.                                                                
ovs_bridge_flow_count                                    bridge     base      gauge    bridge,datapath_type                 The number of openflow rules configured on a bridge.                                            
ovs_coverage_conntrack_lookup_natted_miss_total          coverage   errors    counter                                       conntrack_lookup_natted_miss coverage counter                                                   
ovs_coverage_miniflow_extract_ipv4_pkt_len_error_total   coverage   errors    counter                                       miniflow_extract_ipv4_pkt_len_error coverage counter                                            
ovs_coverage_netdev_add_router_total                     coverage   debug     counter                                       netdev_add_router coverage counter                                                              
ovs_coverage_poll_create_node_total                      coverage   debug     counter                                       poll_create_node coverage counter                                                               
....                                                             
ovs_pmd_sleep_microseconds                               pmd-perf   perf      counter  numa,cpu                             Total time spent sleeping in microseconds                                                       
ovs_pmd_rx_packets                                       pmd-perf   debug     counter  numa,cpu                             Number of packets received                                                                      
ovs_pmd_datapath_passes                                  pmd-perf   debug     counter  numa,cpu                             Number of datapath passes                                                                       
ovs_pmd_cpu_isolated                                     pmd-rxq    perf      gauge    numa,cpu                             1 or 0 whether the CPU is excluded from automatic Rxq balancing.                                
ovs_pmd_cpu_overhead                                     pmd-rxq    perf      gauge    numa,cpu                             Percentage of CPU cycles not related to one specific Rxq.                                       
ovs_pmd_rxq_enabled                                      pmd-rxq    perf      gauge    numa,cpu,interface,rxq               1 or 0 whether a vhost-user Rxq is enabled by a guest.                                          
ovs_pmd_rxq_usage                                        pmd-rxq    perf      gauge    numa,cpu,interface,rxq               Percentage of CPU cycles used to process packets from one Rxq.                                  
ovs_build_info                                           vswitch    base      gauge    ovs_version,dpdk_version,db_version  Version and library from which OVS binaries were built.                                         
ovs_dpdk_initialized                                     vswitch    base      gauge                                         Has the DPDK subsystem been initialized.                                                        

```
</details>

<details>

<summary>
`$ ./dataplane-node-exporter -l markdown`
</summary>

| METRIC | COLLECTOR | SET | TYPE | LABELS | HELP |
| ------ | --------- | --- | ---- | ------ | ---- |
| ovs_bridge_port_count | bridge | base | gauge | bridge,datapath_type | The number of ports in a bridge. |
| ovs_bridge_flow_count | bridge | base | gauge | bridge,datapath_type | The number of openflow rules configured on a bridge. |
| ovs_coverage_datapath_drop_rx_invalid_packet_total | coverage | errors | counter |  | datapath_drop_rx_invalid_packet coverage counter |
| ovs_coverage_poll_zero_timeout_total | coverage | errors | counter |  | poll_zero_timeout coverage counter |
| ovs_coverage_rev_port_toggled_total | coverage | debug | counter |  | rev_port_toggled coverage counter |
| ovs_coverage_vhost_tx_contention_total | coverage | errors | counter |  | vhost_tx_contention coverage counter |
| ovs_coverage_datapath_drop_hw_miss_recover_total | coverage | errors | counter |  | datapath_drop_hw_miss_recover coverage counter |
| ovs_coverage_hindex_pathological_total | coverage | errors | counter |  | hindex_pathological coverage counter |
| ovs_coverage_miniflow_extract_ipv4_pkt_too_short_total | coverage | errors | counter |  | miniflow_extract_ipv4_pkt_too_short coverage counter |
| ovs_coverage_netdev_get_ethtool_total | coverage | debug | counter |  | netdev_get_ethtool coverage counter |
| ovs_coverage_nln_changed_total | coverage | debug | counter |  | nln_changed coverage counter |
| ovs_coverage_ofproto_reinit_ports_total | coverage | debug | counter |  | ofproto_reinit_ports coverage counter |
| ovs_coverage_rev_mcast_snooping_total | coverage | debug | counter |  | rev_mcast_snooping coverage counter |
| ovs_coverage_datapath_drop_sample_error_total | coverage | errors | counter |  | datapath_drop_sample_error coverage counter |
| ovs_coverage_netdev_get_stats_total | coverage | debug | counter |  | netdev_get_stats coverage counter |
| ovs_coverage_process_start_total | coverage | debug | counter |  | process_start coverage counter |
| ovs_coverage_rev_flow_table_total | coverage | debug | counter |  | rev_flow_table coverage counter |
| ovs_coverage_route_table_dump_total | coverage | debug | counter |  | route_table_dump coverage counter |
| ovs_coverage_upcall_flow_limit_scaled_total | coverage | debug | counter |  | upcall_flow_limit_scaled coverage counter |
| ovs_coverage_datapath_drop_upcall_error_total | coverage | errors | counter |  | datapath_drop_upcall_error coverage counter |
| ovs_coverage_drop_action_recirculation_conflict_total | coverage | errors | counter |  | drop_action_recirculation_conflict coverage counter |
| ovs_coverage_netdev_set_ethtool_total | coverage | debug | counter |  | netdev_set_ethtool coverage counter |
| ovs_coverage_txn_forward_create_total | coverage | debug | counter |  | txn_forward_create coverage counter |
| ovs_coverage_afxdp_cq_skip_total | coverage | debug | counter |  | afxdp_cq_skip coverage counter |
| ovs_coverage_dpif_purge_total | coverage | debug | counter |  | dpif_purge coverage counter |
| ovs_coverage_drop_action_bridge_not_found_total | coverage | errors | counter |  | drop_action_bridge_not_found coverage counter |
| ovs_coverage_packet_in_overflow_total | coverage | errors | counter |  | packet_in_overflow coverage counter |
| ovs_coverage_rconn_queued_total | coverage | debug | counter |  | rconn_queued coverage counter |
| ovs_coverage_upcall_flow_limit_reduced_total | coverage | debug | counter |  | upcall_flow_limit_reduced coverage counter |
| ovs_coverage_mcast_snooping_expired_total | coverage | debug | counter |  | mcast_snooping_expired coverage counter |
| ovs_coverage_netdev_get_hwaddr_total | coverage | debug | counter |  | netdev_get_hwaddr coverage counter |
| ... | ... | ... | ... | ... | ... |
| ovs_pmd_megaflow_hits | pmd-perf | debug | counter | numa,cpu | megaflow hits |
| ovs_pmd_lost_upcalls | pmd-perf | errors | counter | numa,cpu | Number of lost upcalls |
| ovs_pmd_idle_iterations | pmd-perf | perf | counter | numa,cpu | Number of iterations where zero packets where received |
| ovs_pmd_sleep_iterations | pmd-perf | perf | counter | numa,cpu | Number of iterations spent sleeping |
| ovs_pmd_simple_match_hits | pmd-perf | debug | counter | numa,cpu | simple match hits |
| ovs_pmd_emc_hits | pmd-perf | debug | counter | numa,cpu | emc hits |
| ovs_pmd_smc_hits | pmd-perf | debug | counter | numa,cpu | smc hits |
| ovs_pmd_tx_packets | pmd-perf | debug | counter | numa,cpu | Number of Tx packets |
| ovs_pmd_tx_batches | pmd-perf | debug | gauge | numa,cpu | Number of Tx batches |
| ovs_pmd_busy_iterations | pmd-perf | perf | counter | numa,cpu | Number of iterations spent processing packets |
| ovs_pmd_sleep_microseconds | pmd-perf | perf | counter | numa,cpu | Total time spent sleeping in microseconds |
| ovs_pmd_total_upcalls | pmd-perf | perf | counter | numa,cpu | Number of upcalls |
| ovs_pmd_cpu_isolated | pmd-rxq | perf | gauge | numa,cpu | 1 or 0 whether the CPU is excluded from automatic Rxq balancing. |
| ovs_pmd_cpu_overhead | pmd-rxq | perf | gauge | numa,cpu | Percentage of CPU cycles not related to one specific Rxq. |
| ovs_pmd_rxq_enabled | pmd-rxq | perf | gauge | numa,cpu,interface,rxq | 1 or 0 whether a vhost-user Rxq is enabled by a guest. |
| ovs_pmd_rxq_usage | pmd-rxq | perf | gauge | numa,cpu,interface,rxq | Percentage of CPU cycles used to process packets from one Rxq. |
| ovs_build_info | vswitch | base | gauge | ovs_version,dpdk_version,db_version | Version and library from which OVS binaries were built. |
| ovs_dpdk_initialized | vswitch | base | gauge |  | Has the DPDK subsystem been initialized. |

</details>