### PR TITLE
config: add new ovs-procdir setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ socket path is resolved using the PID file of `ovs-vswitchd` at
 `/run/openvswitch/ovs-vswitchd.pid` =>
 `/run/openvswitch/ovs-vswitchd.$PID.ctl`.
 
+Some collectors will need access to the `/proc/$PID` directory of
+`ovs-vswitchd`.
+
 The collector for OVN will need access to the `ovn-controller` unixctl socket. This
 socket path is resolved using the PID file of `ovn-controller` at
 `/run/ovn/ovn-controller.pid` => `/run/ovn/ovn-controller.$PID.ctl`.

--- a/collectors/pmd_rxq/collector.go
+++ b/collectors/pmd_rxq/collector.go
@@ -191,7 +191,7 @@ func getVswitchdPmdStat() map[uint64]pmdstat {
 		log.Errf("read(%s): %s", pidfile, err)
 		return nil
 	}
-	tasks := filepath.Join("/proc", strings.TrimSpace(string(buf)), "task")
+	tasks := filepath.Join(config.OvsProcdir(), strings.TrimSpace(string(buf)), "task")
 	entries, err := os.ReadDir(tasks)
 	if err != nil {
 		log.Errf("readdir(%s): %s", tasks, err)

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type conf struct {
 	users      map[string]string `yaml:"-"`
 	OvsRundir  string            `yaml:"ovs-rundir" env:"DATAPLANE_NODE_EXPORTER_OVS_RUNDIR"`
 	OvnRundir  string            `yaml:"ovn-rundir" env:"DATAPLANE_NODE_EXPORTER_OVN_RUNDIR"`
+	OvsProcdir string            `yaml:"ovs-procdir" env:"DATAPLANE_NODE_EXPORTER_OVS_PROCDIR"`
 	LogLevel   string            `yaml:"log-level" env:"DATAPLANE_NODE_EXPORTER_LOG_LEVEL"`
 	logLevel   syslog.Priority   `yaml:"-"`
 	Collectors []string          `yaml:"collectors"`
@@ -78,6 +79,7 @@ var c = conf{
 	HttpPath:   "/metrics",
 	OvsRundir:  "/run/openvswitch",
 	OvnRundir:  "/run/ovn",
+	OvsProcdir: "/proc",
 	LogLevel:   "notice",
 	users:      make(map[string]string),
 }
@@ -88,6 +90,7 @@ func TlsCert() string              { return c.TlsCert }
 func TlsKey() string               { return c.TlsKey }
 func OvsRundir() string            { return c.OvsRundir }
 func OvnRundir() string            { return c.OvnRundir }
+func OvsProcdir() string           { return c.OvsProcdir }
 func Collectors() []string         { return c.Collectors }
 func LogLevel() syslog.Priority    { return c.logLevel }
 func AuthUsers() map[string]string { return c.users }

--- a/etc/dataplane-node-exporter.yaml
+++ b/etc/dataplane-node-exporter.yaml
@@ -85,6 +85,15 @@
 #
 #ovs-rundir: /run/openvswitch
 
+# The mount path of the procfs directory to search for the PID found in
+# ovs-vswitchd.pid. When running the exporter in a different PID namespace than
+# OVS, this will need to be changed to another folder.
+#
+# Env: DATAPLANE_NODE_EXPORTER_OVS_PROCDIR
+# Default: /proc
+#
+#ovs-procdir: /proc
+
 # List of metric collectors to scrape and export. To list the available
 # collectors and the metrics they export, use "dataplane-node-exporter -l". If
 # the list is empty (default) all collectors will be enabled.


### PR DESCRIPTION
When running the exporter in a container, the PID namespace is different and /proc only contains "1" (the process of the exporter). This leads to an error when collecting context switches stats:

    ERROR readdir: open /proc/143795/task: no such file or directory

Add a setting to specify where the /proc folder of the PID namespace of ovs-vswitchd (usually the base namespace) is mounted. By default, assume everything is running in the same namespace.

Reported-by: Aaron Smith <aasmith@redhat.com>