### PR TITLE
iface: ignore dpdk specific counters when zero

### DIFF
--- a/collectors/iface/metrics.go
+++ b/collectors/iface/metrics.go
@@ -145,7 +145,7 @@ var metrics = []Metric{
 			Set:         config.METRICS_ERRORS,
 		},
 		func(iface *ovs.Interface) float64 {
-			if x, ok := iface.Statistics["rx_missed_errors"]; ok {
+			if x := iface.Statistics["rx_missed_errors"]; x > 0 {
 				return float64(x)
 			}
 			return float64(iface.Statistics["rx_dropped"])
@@ -184,10 +184,10 @@ var metrics = []Metric{
 			Set:         config.METRICS_ERRORS,
 		},
 		func(iface *ovs.Interface) float64 {
-			if x, ok := iface.Statistics["tx_errors"]; ok {
+			if x := iface.Statistics["ovs_tx_failure_drops"]; x > 0 {
 				return float64(x)
 			}
-			return float64(iface.Statistics["ovs_tx_failure_drops"])
+			return float64(iface.Statistics["tx_errors"])
 		},
 	},
 	{


### PR DESCRIPTION
Some interfaces have both counters and the DPDK specific counters (rx_missed_errors and ovs_tx_failure_drops) are always 0.

When DPDK specific counters are absent or are 0, ignore them and return the generic counter instead.