### PR TITLE
iface: replace empty type with system

### DIFF
--- a/collectors/iface/collector.go
+++ b/collectors/iface/collector.go
@@ -80,6 +80,10 @@ func (Collector) Collect(ch chan<- prometheus.Metric) {
 		if !ok {
 			continue
 		}
+		if i.Type == "" {
+			// empty string is a synonym for "system"
+			i.Type = "system"
+		}
 		labels := []string{bridge, port, i.Name, i.Type}
 
 		for _, m := range metrics {


### PR DESCRIPTION
The ovs man page explains that type="" is synonym to type="system".