### PR TITLE
context_switches missing in the list of stats

### DIFF
--- a/collectors/pmd_rxq/collector.go
+++ b/collectors/pmd_rxq/collector.go
@@ -27,7 +27,7 @@ func (Collector) Name() string {
 }
 
 func (Collector) Metrics() []lib.Metric {
-	return []lib.Metric{isolatedMetric, overheadMetric, enabledMetric, usageMetric}
+	return []lib.Metric{isolatedMetric, overheadMetric, ctxtSwitchesMetric, nonVolCtxtSwitchesMetric, enabledMetric, usageMetric}
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {


### PR DESCRIPTION
They were generated, but they were not reported in the list of available stats