### PR TITLE
collectors: Add ovnc_bridge_mappings to Metrics()

### DIFF
--- a/collectors/ovn/collector.go
+++ b/collectors/ovn/collector.go
@@ -194,6 +194,7 @@ func (Collector) Metrics() []lib.Metric {
 			res = append(res, m)
 		}
 	}
+	res = append(res, bridgeMappings)
 	return res
 }
 


### PR DESCRIPTION
When the collection of ovnc_bridge_mappings was added to the OVN collector, it wasn't added to the list of metrics advertised by the corresponding Metrics() method. This commit fixes that.