### PR TITLE
collectors: add logical router stats to ovn collector

### DIFF
--- a/collectors/ovn/metrics.go
+++ b/collectors/ovn/metrics.go
@@ -197,9 +197,27 @@ var ovnController = map[string]lib.Metric{
 	},
 }
 
+var ovnRouterPortTraffic = map[string]lib.Metric{
+	routerporttrafficpkts: {
+		Name:        "ovnc_router_port_traffic_pkts",
+		Description: "Number of packets transmitted and received by a logical router port labeled by the logical datapath number and the logical port number",
+		Labels:      []string{"datapath", "port"},
+		ValueType:   prometheus.GaugeValue,
+		Set:         config.METRICS_BASE,
+	},
+	"ovn-router-port-traffic-bytes": {
+		Name:        "ovnc_router_port_traffic_bytes",
+		Description: "Number of bytes transmitted and received by a logical router port labeled by the logical datapath number and the logical port number",
+		Labels:      []string{"datapath", "port"},
+		ValueType:   prometheus.GaugeValue,
+		Set:         config.METRICS_BASE,
+	},
+}
+
 var metrics = []*map[string]lib.Metric{
 	&openvSwitch,
 	&openvSwitchBoolean,
 	&openvSwitchLabels,
 	&ovnController,
+	&ovnRouterPortTraffic,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ type conf struct {
 	Collectors []string          `yaml:"collectors"`
 	MetricSets []string          `yaml:"metric-sets"`
 	metricSets MetricSet         `yaml:"-"`
+	IntBrdNam  string            `yaml:"br-int-name" env:"OPENSTACK_NETWORK_EXPORTER_BR_INT_NAME"`
 }
 
 var c = conf{
@@ -82,6 +83,7 @@ var c = conf{
 	OvsProcdir: "/proc",
 	LogLevel:   "notice",
 	users:      make(map[string]string),
+	IntBrdNam:  "br-int",
 }
 
 func HttpListen() string           { return c.HttpListen }
@@ -95,6 +97,7 @@ func Collectors() []string         { return c.Collectors }
 func LogLevel() syslog.Priority    { return c.logLevel }
 func AuthUsers() map[string]string { return c.users }
 func MetricSets() MetricSet        { return c.metricSets }
+func IntBrdNam() string            { return c.IntBrdNam }
 
 func Parse() error {
 	path, configInEnv := os.LookupEnv("OPENSTACK_NETWORK_EXPORTER_YAML")

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/skydive-project/goloxi v0.0.0-20190117172159-db2324197a3e // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/skydive-project/goloxi v0.0.0-20190117172159-db2324197a3e h1:+YbV6iSx94jWUeoMFqu7o6UqBYjbUS/pi1kAeUEL854=
+github.com/skydive-project/goloxi v0.0.0-20190117172159-db2324197a3e/go.mod h1:3lfQAv6I4MTGbTmT66GhevjIBSF5JPevnKByW0bumXY=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=


### PR DESCRIPTION
Collection of the traffic through the logical router ports is added to the ovn collector. Both bytes and packets counts are collected.