### PR TITLE
collectors: added ovn northd metrics collector

### DIFF
--- a/appctl/appctl.go
+++ b/appctl/appctl.go
@@ -10,6 +10,7 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -22,7 +23,57 @@ type appctlDaemon string
 const (
 	ovsVswitchd   appctlDaemon = "ovs-vswitchd"
 	ovnController appctlDaemon = "ovn-controller"
+	ovnNorthd     appctlDaemon = "ovn-northd"
 )
+
+func getPidFromFile(pidfile string) (int, error) {
+	f, err := os.Open(pidfile)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf)))
+	if err != nil {
+		return 0, err
+	}
+
+	return pid, nil
+}
+
+func getPidFromCtlFiles(rundir string, daemon appctlDaemon) (int, error) {
+	// Look for .ctl files matching the daemon pattern
+	pattern := fmt.Sprintf("%s.*.ctl", daemon)
+	matches, err := filepath.Glob(filepath.Join(rundir, pattern))
+	if err != nil {
+		return 0, err
+	}
+
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("no control socket files found for %s", daemon)
+	}
+
+	// Extract PID from the first matching file
+	// Expected format: daemon.pid.ctl
+	re := regexp.MustCompile(fmt.Sprintf(`%s\.(\d+)\.ctl$`, regexp.QuoteMeta(string(daemon))))
+	for _, match := range matches {
+		basename := filepath.Base(match)
+		submatch := re.FindStringSubmatch(basename)
+		if len(submatch) == 2 {
+			pid, err := strconv.Atoi(submatch[1])
+			if err == nil {
+				return pid, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("could not extract PID from control socket files for %s", daemon)
+}
 
 func call(daemon appctlDaemon, method string, args ...string) string {
 	var rundir string
@@ -33,28 +84,26 @@ func call(daemon appctlDaemon, method string, args ...string) string {
 		rundir = config.OvsRundir()
 	case ovnController:
 		rundir = config.OvnRundir()
+	case ovnNorthd:
+		rundir = config.OvnRundir()
 	default:
 		panic(fmt.Errorf("unknown daemon value: %v", daemon))
 	}
 
 	pidfile := filepath.Join(rundir, fmt.Sprintf("%s.pid", daemon))
 
-	var f *os.File
-	if f, err = os.Open(pidfile); err != nil {
-		log.Errf("os.Open: %s", err)
-		return ""
-	}
-	var buf []byte
-	if buf, err = io.ReadAll(f); err != nil {
-		log.Errf("io.ReadAll: %s", err)
-		return ""
+	// First try to get PID from .pid file
+	pid, err := getPidFromFile(pidfile)
+	if err != nil {
+		log.Debugf("Failed to read PID file %s: %s, trying to find PID from .ctl files", pidfile, err)
+		// If that fails, try to extract PID from .ctl files
+		pid, err = getPidFromCtlFiles(rundir, daemon)
+		if err != nil {
+			log.Errf("Failed to get PID for %s: %s", daemon, err)
+			return ""
+		}
 	}
 
-	var pid int
-	if pid, err = strconv.Atoi(strings.TrimSpace(string(buf))); err != nil {
-		log.Errf("strconv.Atoi: %s", err)
-		return ""
-	}
 	sockpath := filepath.Join(rundir, fmt.Sprintf("%s.%d.ctl", daemon, pid))
 	conn, err := net.Dial("unix", sockpath)
 	if err != nil {
@@ -91,4 +140,8 @@ func OvsVSwitchd(method string, args ...string) string {
 
 func OvnController(method string, args ...string) string {
 	return call(ovnController, method, args...)
+}
+
+func OvnNorthd(method string, args ...string) string {
+	return call(ovnNorthd, method, args...)
 }

--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/memory"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovn"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovnnorthd"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_perf"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_rxq"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/vswitch"
@@ -23,6 +24,7 @@ var collectors = []lib.Collector{
 	new(datapath.Collector),
 	new(iface.Collector),
 	new(memory.Collector),
+	new(ovnnorthd.Collector),
 	new(ovn.Collector),
 	new(pmd_perf.Collector),
 	new(pmd_rxq.Collector),

--- a/collectors/ovnnorthd/collector.go
+++ b/collectors/ovnnorthd/collector.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Yatin Karel
+
+package ovnnorthd
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Collector struct{}
+
+func (Collector) Name() string {
+	return "ovnnorthd"
+}
+
+func (Collector) Metrics() []lib.Metric {
+	var res []lib.Metric
+	for _, m := range coverageMetrics {
+		res = append(res, m)
+	}
+	res = append(res, statusMetric)
+	return res
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	lib.DescribeEnabledMetrics(c, ch)
+}
+
+func makeMetric(name, value string) prometheus.Metric {
+	m, ok := coverageMetrics[name]
+	if !ok {
+		return nil
+	}
+	if !config.MetricSets().Has(m.Set) {
+		return nil
+	}
+
+	val, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		log.Errf("%s: %s: %s", name, value, err)
+		return nil
+	}
+
+	return prometheus.MustNewConstMetric(m.Desc(), m.ValueType, val)
+}
+
+// "pstream_open                 0.0/sec     0.000/sec        0.0000/sec   total: 1"
+var coverageRe = regexp.MustCompile(`^(\w+)\s+.*\s+total: (\d+)$`)
+
+func collectCoverageMetrics(ch chan<- prometheus.Metric) {
+	buf := appctl.OvnNorthd("coverage/show")
+	if buf == "" {
+		return
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(buf))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		match := coverageRe.FindStringSubmatch(line)
+		if match != nil {
+			metric := makeMetric(match[1], match[2])
+			if metric != nil {
+				ch <- metric
+			}
+		}
+	}
+}
+
+func collectStatusMetric(ch chan<- prometheus.Metric) {
+	if !config.MetricSets().Has(statusMetric.Set) {
+		return
+	}
+
+	buf := appctl.OvnNorthd("status")
+	if buf == "" {
+		return
+	}
+
+	var value float64
+	status := strings.TrimSpace(buf)
+
+	// Parse status from output like "Status: active"
+	if strings.Contains(status, "Status:") {
+		parts := strings.Split(status, ":")
+		if len(parts) == 2 {
+			statusValue := strings.TrimSpace(parts[1])
+			switch statusValue {
+			case "active":
+				value = 1.0
+			case "standby":
+				value = 0.0
+			case "paused":
+				value = 2.0
+			default:
+				log.Warningf("Unknown northd status: %s", statusValue)
+				return
+			}
+		} else {
+			log.Warningf("Unexpected status format: %s", status)
+			return
+		}
+	} else {
+		log.Warningf("Status output does not contain 'Status:' prefix: %s", status)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(statusMetric.Desc(), statusMetric.ValueType, value)
+}
+
+func (Collector) Collect(ch chan<- prometheus.Metric) {
+	// Collect coverage metrics
+	collectCoverageMetrics(ch)
+
+	// Collect status metric
+	collectStatusMetric(ch)
+}

--- a/collectors/ovnnorthd/metrics.go
+++ b/collectors/ovnnorthd/metrics.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Yatin Karel
+
+package ovnnorthd
+
+import (
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Coverage metrics for OVN northd
+var coverageMetrics = map[string]lib.Metric{
+	"pstream_open": {
+		Name:        "ovn_northd_pstream_open_total",
+		Description: "Specifies the number of time passive connections were opened for the remote peer to connect",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_COUNTERS,
+	},
+	"stream_open": {
+		Name:        "ovn_northd_stream_open_total",
+		Description: "Specifies the number of attempts to connect to a remote peer",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_COUNTERS,
+	},
+	"txn_success": {
+		Name:        "ovn_northd_txn_success_total",
+		Description: "Specifies the number of times the OVSDB transaction has successfully completed",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_COUNTERS,
+	},
+	"txn_error": {
+		Name:        "ovn_northd_txn_error_total",
+		Description: "Specifies the number of times the OVSDB transaction has errored out",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_ERRORS,
+	},
+	"txn_uncommitted": {
+		Name:        "ovn_northd_txn_uncommitted_total",
+		Description: "Specifies the number of times the OVSDB transaction were uncommitted",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_ERRORS,
+	},
+	"txn_unchanged": {
+		Name:        "ovn_northd_txn_unchanged_total",
+		Description: "Specifies the number of times the OVSDB transaction resulted in no change to the database",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_COUNTERS,
+	},
+	"txn_incomplete": {
+		Name:        "ovn_northd_txn_incomplete_total",
+		Description: "Specifies the number of times the OVSDB transaction did not complete and the client had to re-try",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_ERRORS,
+	},
+	"txn_aborted": {
+		Name:        "ovn_northd_txn_aborted_total",
+		Description: "Specifies the number of times the OVSDB transaction has been aborted",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_ERRORS,
+	},
+	"txn_try_again": {
+		Name:        "ovn_northd_txn_try_again_total",
+		Description: "Specifies the number of times the OVSDB transaction failed and the client had to re-try",
+		ValueType:   prometheus.CounterValue,
+		Set:         config.METRICS_ERRORS,
+	},
+}
+
+// Status metric for OVN northd
+var statusMetric = lib.Metric{
+	Name:        "ovn_northd_status",
+	Description: "Status of OVN northd (0=standby, 1=active, 2=paused)",
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}

--- a/etc/openstack-network-exporter.yaml
+++ b/etc/openstack-network-exporter.yaml
@@ -66,9 +66,10 @@
 #
 #log-level: notice
 
-# The absolute path to the runtime directory of ovn-controller. This folder is
-# expected to contain the the ovn-controller pid file "ovn-controller.pid" and
-# its unixctl socket "ovn-controller.$pid.ctl".
+# The absolute path to the runtime directory of the ovn services. This folder
+# is expected to contain the ovn services pid file like "<service>.pid" and
+# its unixctl socket like "<service>.$pid.ctl". If "<service>.pid" is missing
+# unixctl socket will be located in the folder with regex "<service>.*.ctl"
 #
 # Env: OPENSTACK_NETWORK_EXPORTER_OVN_RUNDIR
 # Default: /run/ovn


### PR DESCRIPTION
This new collector will be used for collecting metrics of OVN Northd running on OCP worker nodes as pod.

Following metrics are exposed:-
ovn_northd_txn_success_total
ovn_northd_txn_incomplete_total
ovn_northd_txn_aborted_total
ovn_northd_txn_unchanged_total
ovn_northd_txn_try_again_total
ovn_northd_pstream_open_total
ovn_northd_stream_open_total
ovn_northd_txn_error_total
ovn_northd_txn_uncommitted_total
ovn_northd_status

These are collected using below commands:-
ovn-appctl -t ovn-northd.1.ctl coverage/show
ovn-appctl -t ovn-northd.1.ctl status

Also since northd not running with --pidfile option adapted the code to work if that is missing.

Closes: https://issues.redhat.com/browse/OSPRH-12565