### PR TITLE
test: run apt-get update before package installation

### DIFF
--- a/test/config_test_environment.sh
+++ b/test/config_test_environment.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+apt-get update -y
 apt-get install openvswitch-switch-dpdk iperf3 socat -y
 update-alternatives --set ovs-vswitchd \
 	/usr/lib/openvswitch-switch-dpdk/ovs-vswitchd-dpdk


### PR DESCRIPTION
make test job is failing to install packages, in
order to fix that refresh metadata.