### PR TITLE
collectors: add ovsdbserver for ovn raft cluster metrics

### DIFF
--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/memory"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovn"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovnnorthd"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovsdbserver"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_perf"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_rxq"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/vswitch"
@@ -26,6 +27,7 @@ var collectors = []lib.Collector{
 	new(memory.Collector),
 	new(ovnnorthd.Collector),
 	new(ovn.Collector),
+	new(ovsdbserver.Collector),
 	new(pmd_perf.Collector),
 	new(pmd_rxq.Collector),
 	new(vswitch.Collector),

--- a/collectors/ovsdbserver/collector.go
+++ b/collectors/ovsdbserver/collector.go
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 Miguel Lavalle
+
+package ovsdbserver
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type raftClusterInfo struct {
+	database        string
+	clusterUUID     string
+	serverUUID      string
+	role            string
+	status          string
+	vote            string
+	term            int
+	electionTimer   int
+	logStart        int
+	logNext         int
+	logNotCommitted int
+	logNotApplied   int
+	inboundConns    int
+	outboundConns   int
+	isLeader        bool
+}
+
+var (
+	// Regular expressions for parsing cluster status output
+	clusterIdRe     = regexp.MustCompile(`^Cluster ID: (\w+) \(([^)]+)\)$`)
+	serverIdRe      = regexp.MustCompile(`^Server ID: (\w+) \(([^)]+)\)$`)
+	roleRe          = regexp.MustCompile(`^Role: (.+)$`)
+	statusRe        = regexp.MustCompile(`^Status: (.+)$`)
+	termRe          = regexp.MustCompile(`^Term: (\d+)$`)
+	voteRe          = regexp.MustCompile(`^Vote: (.+)$`)
+	electionTimerRe = regexp.MustCompile(`^Election timer: (\d+)$`)
+	logRe           = regexp.MustCompile(`^Log: \[(\d+), (\d+)\]$`)
+	notCommittedRe  = regexp.MustCompile(`^Entries not yet committed: (\d+)$`)
+	notAppliedRe    = regexp.MustCompile(`^Entries not yet applied: (\d+)$`)
+	connectionsRe   = regexp.MustCompile(`^Connections: (.+)$`)
+	nameRe          = regexp.MustCompile(`^Name: (.+)$`)
+)
+
+func parseConnections(connStr string) (int, int) {
+	// Parse connections like "<-200e ->200e <-cd93 ->cd93"
+	inbound := 0
+	outbound := 0
+
+	parts := strings.Fields(connStr)
+	for _, part := range parts {
+		if strings.HasPrefix(part, "<-") {
+			inbound++
+		} else if strings.HasPrefix(part, "->") {
+			outbound++
+		}
+	}
+
+	return inbound, outbound
+}
+
+func parseClusterStatus(output string) (*raftClusterInfo, error) {
+	info := &raftClusterInfo{}
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		switch {
+		case nameRe.MatchString(line):
+			match := nameRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				info.database = match[1]
+			}
+
+		case clusterIdRe.MatchString(line):
+			match := clusterIdRe.FindStringSubmatch(line)
+			if len(match) == 3 {
+				info.clusterUUID = match[2] // Use full UUID
+			}
+
+		case serverIdRe.MatchString(line):
+			match := serverIdRe.FindStringSubmatch(line)
+			if len(match) == 3 {
+				info.serverUUID = match[2] // Use full UUID
+			}
+
+		case roleRe.MatchString(line):
+			match := roleRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				info.role = match[1]
+				info.isLeader = (match[1] == "leader")
+			}
+
+		case statusRe.MatchString(line):
+			match := statusRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				info.status = match[1]
+			}
+
+		case voteRe.MatchString(line):
+			match := voteRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				info.vote = match[1]
+			}
+
+		case termRe.MatchString(line):
+			match := termRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				if val, err := strconv.Atoi(match[1]); err == nil {
+					info.term = val
+				}
+			}
+
+		case electionTimerRe.MatchString(line):
+			match := electionTimerRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				if val, err := strconv.Atoi(match[1]); err == nil {
+					info.electionTimer = val
+				}
+			}
+
+		case logRe.MatchString(line):
+			match := logRe.FindStringSubmatch(line)
+			if len(match) == 3 {
+				if start, err := strconv.Atoi(match[1]); err == nil {
+					info.logStart = start
+				}
+				if next, err := strconv.Atoi(match[2]); err == nil {
+					info.logNext = next
+				}
+			}
+
+		case notCommittedRe.MatchString(line):
+			match := notCommittedRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				if val, err := strconv.Atoi(match[1]); err == nil {
+					info.logNotCommitted = val
+				}
+			}
+
+		case notAppliedRe.MatchString(line):
+			match := notAppliedRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				if val, err := strconv.Atoi(match[1]); err == nil {
+					info.logNotApplied = val
+				}
+			}
+
+		case connectionsRe.MatchString(line):
+			match := connectionsRe.FindStringSubmatch(line)
+			if len(match) == 2 {
+				info.inboundConns, info.outboundConns = parseConnections(match[1])
+			}
+		}
+	}
+
+	return info, scanner.Err()
+}
+
+func collectRaftMetrics(info *raftClusterInfo, ch chan<- prometheus.Metric) {
+	baseLabels := []string{info.database, info.clusterUUID, info.serverUUID}
+
+	// Cluster election timer
+	if config.MetricSets().Has(clusterElectionTimer.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterElectionTimer.Desc(), clusterElectionTimer.ValueType,
+			float64(info.electionTimer), baseLabels...)
+	}
+
+	// Cluster ID (constant 1.0)
+	if config.MetricSets().Has(clusterId.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterId.Desc(), clusterId.ValueType,
+			1.0, info.database, info.clusterUUID)
+	}
+
+	// Cluster Server ID (constant 1.0)
+	if config.MetricSets().Has(clusterServerId.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterServerId.Desc(), clusterServerId.ValueType,
+			1.0, baseLabels...)
+	}
+
+	// Cluster Server Role (constant 1.0)
+	if config.MetricSets().Has(clusterServerRole.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterServerRole.Desc(), clusterServerRole.ValueType,
+			1.0, append(baseLabels, info.role)...)
+	}
+
+	// Cluster Server Status (constant 1.0)
+	if config.MetricSets().Has(clusterServerStatus.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterServerStatus.Desc(), clusterServerStatus.ValueType,
+			1.0, append(baseLabels, info.status)...)
+	}
+
+	// Cluster Server Vote (constant 1.0)
+	if config.MetricSets().Has(clusterServerVote.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterServerVote.Desc(), clusterServerVote.ValueType,
+			1.0, append(baseLabels, info.vote)...)
+	}
+
+	// Cluster Term
+	if config.MetricSets().Has(clusterTerm.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterTerm.Desc(), clusterTerm.ValueType,
+			float64(info.term), baseLabels...)
+	}
+
+	// Cluster Leader (1.0 if leader, 0.0 if not)
+	if config.MetricSets().Has(clusterLeader.Set) {
+		var leaderValue float64
+		if info.isLeader {
+			leaderValue = 1.0
+		} else {
+			leaderValue = 0.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			clusterLeader.Desc(), clusterLeader.ValueType,
+			leaderValue, baseLabels...)
+	}
+
+	// Inbound connections
+	if config.MetricSets().Has(clusterInboundConnectionsTotal.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterInboundConnectionsTotal.Desc(), clusterInboundConnectionsTotal.ValueType,
+			float64(info.inboundConns), baseLabels...)
+	}
+
+	// Outbound connections
+	if config.MetricSets().Has(clusterOutboundConnectionsTotal.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterOutboundConnectionsTotal.Desc(), clusterOutboundConnectionsTotal.ValueType,
+			float64(info.outboundConns), baseLabels...)
+	}
+
+	// Log entry index
+	if config.MetricSets().Has(logEntryIndex.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			logEntryIndex.Desc(), logEntryIndex.ValueType,
+			float64(info.logStart), baseLabels...)
+	}
+
+	// Log index next
+	if config.MetricSets().Has(clusterLogIndexNext.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterLogIndexNext.Desc(), clusterLogIndexNext.ValueType,
+			float64(info.logNext), baseLabels...)
+	}
+
+	// Log not committed
+	if config.MetricSets().Has(clusterLogNotCommitted.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterLogNotCommitted.Desc(), clusterLogNotCommitted.ValueType,
+			float64(info.logNotCommitted), baseLabels...)
+	}
+
+	// Log not applied
+	if config.MetricSets().Has(clusterLogNotApplied.Set) {
+		ch <- prometheus.MustNewConstMetric(
+			clusterLogNotApplied.Desc(), clusterLogNotApplied.ValueType,
+			float64(info.logNotApplied), baseLabels...)
+	}
+}
+
+type Collector struct{}
+
+func (Collector) Name() string {
+	return "ovsdbserver"
+}
+
+func (Collector) Metrics() []lib.Metric {
+	return metrics
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	lib.DescribeEnabledMetrics(c, ch)
+}
+
+func (Collector) Collect(ch chan<- prometheus.Metric) {
+	output := appctl.OvsDbServer("cluster/status")
+	if output == "" {
+		log.Debugf("No OVN Raft cluster status output available")
+		return
+	}
+
+	info, err := parseClusterStatus(output)
+	if err != nil {
+		log.Errf("Failed to parse OVN Raft cluster status: %s", err)
+		return
+	}
+
+	collectRaftMetrics(info, ch)
+}

--- a/collectors/ovsdbserver/metrics.go
+++ b/collectors/ovsdbserver/metrics.go
@@ -1,0 +1,136 @@
+package ovsdbserver
+
+import (
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var clusterElectionTimer = lib.Metric{
+	Name:        "ovn_raft_cluster_election_timer",
+	Description: "A metric with the value of the election timer labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterId = lib.Metric{
+	Name:        "ovn_raft_cluster_id",
+	Description: "A metric with a constant '1' value labeled by database name and cluster uuid",
+	Labels:      []string{"database", "cluster_uuid"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterServerId = lib.Metric{
+	Name:        "ovn_raft_cluster_server_id",
+	Description: "A metric with a constant '1' value labeled by database name, cluster uuid and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterServerRole = lib.Metric{
+	Name:        "ovn_raft_cluster_server_role",
+	Description: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid and role",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid", "role"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterServerStatus = lib.Metric{
+	Name:        "ovn_raft_cluster_server_status",
+	Description: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid and status",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid", "status"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterServerVote = lib.Metric{
+	Name:        "ovn_raft_cluster_server_vote",
+	Description: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid and vote",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid", "vote"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterTerm = lib.Metric{
+	Name:        "ovn_raft_cluster_term",
+	Description: "A metric with the value of the cluster term labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterLeader = lib.Metric{
+	Name:        "ovn_raft_cluster_leader",
+	Description: "A metric with value 1.0 if the server is the cluster leader for the given database or 0.0 if it is not, labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.GaugeValue,
+	Set:         config.METRICS_BASE,
+}
+
+var clusterInboundConnectionsTotal = lib.Metric{
+	Name:        "ovn_raft_cluster_inbound_connections_total",
+	Description: "A metric with the value of total number of inbound connections to the server labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var clusterOutboundConnectionsTotal = lib.Metric{
+	Name:        "ovn_raft_cluster_outbound_connections_total",
+	Description: "A metric with the value of the total number of outbound connections from the server labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var logEntryIndex = lib.Metric{
+	Name:        "ovn_raft_log_entry_index",
+	Description: "A metric with the value of log entry index currently exposed to clients, labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var clusterLogIndexNext = lib.Metric{
+	Name:        "ovn_raft_cluster_log_index_next",
+	Description: "A metric with the value of the next log entry index labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var clusterLogNotCommitted = lib.Metric{
+	Name:        "ovn_raft_cluster_log_not_committed",
+	Description: "A metric with the value of the number of log entries not committed labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var clusterLogNotApplied = lib.Metric{
+	Name:        "ovn_raft_cluster_log_not_applied",
+	Description: "A metric with the value of the number of log entries not applied labeled by database name, cluster uuid, and server uuid",
+	Labels:      []string{"database", "cluster_uuid", "server_uuid"},
+	ValueType:   prometheus.CounterValue,
+	Set:         config.METRICS_COUNTERS,
+}
+
+var metrics = []lib.Metric{
+	clusterElectionTimer,
+	clusterId,
+	clusterServerId,
+	clusterServerRole,
+	clusterServerStatus,
+	clusterServerVote,
+	clusterTerm,
+	clusterLeader,
+	clusterInboundConnectionsTotal,
+	clusterOutboundConnectionsTotal,
+	logEntryIndex,
+	clusterLogIndexNext,
+	clusterLogNotCommitted,
+	clusterLogNotApplied,
+}

--- a/config/config.go
+++ b/config/config.go
@@ -58,32 +58,34 @@ type user struct {
 }
 
 type conf struct {
-	HttpListen string            `yaml:"http-listen" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_LISTEN"`
-	HttpPath   string            `yaml:"http-path" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_PATH"`
-	TlsCert    string            `yaml:"tls-cert" env:"OPENSTACK_NETWORK_EXPORTER_TLS_CERT"`
-	TlsKey     string            `yaml:"tls-key" env:"OPENSTACK_NETWORK_EXPORTER_TLS_KEY"`
-	AuthUsers  []user            `yaml:"auth-users"`
-	users      map[string]string `yaml:"-"`
-	OvsRundir  string            `yaml:"ovs-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_RUNDIR"`
-	OvnRundir  string            `yaml:"ovn-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVN_RUNDIR"`
-	OvsProcdir string            `yaml:"ovs-procdir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_PROCDIR"`
-	LogLevel   string            `yaml:"log-level" env:"OPENSTACK_NETWORK_EXPORTER_LOG_LEVEL"`
-	logLevel   syslog.Priority   `yaml:"-"`
-	Collectors []string          `yaml:"collectors"`
-	MetricSets []string          `yaml:"metric-sets"`
-	metricSets MetricSet         `yaml:"-"`
-	IntBrdNam  string            `yaml:"br-int-name" env:"OPENSTACK_NETWORK_EXPORTER_BR_INT_NAME"`
+	HttpListen  string            `yaml:"http-listen" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_LISTEN"`
+	HttpPath    string            `yaml:"http-path" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_PATH"`
+	TlsCert     string            `yaml:"tls-cert" env:"OPENSTACK_NETWORK_EXPORTER_TLS_CERT"`
+	TlsKey      string            `yaml:"tls-key" env:"OPENSTACK_NETWORK_EXPORTER_TLS_KEY"`
+	AuthUsers   []user            `yaml:"auth-users"`
+	users       map[string]string `yaml:"-"`
+	OvsRundir   string            `yaml:"ovs-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_RUNDIR"`
+	OvnRundir   string            `yaml:"ovn-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVN_RUNDIR"`
+	OvsdbRundir string            `yaml:"ovsdb-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVSDB_RUNDIR"`
+	OvsProcdir  string            `yaml:"ovs-procdir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_PROCDIR"`
+	LogLevel    string            `yaml:"log-level" env:"OPENSTACK_NETWORK_EXPORTER_LOG_LEVEL"`
+	logLevel    syslog.Priority   `yaml:"-"`
+	Collectors  []string          `yaml:"collectors"`
+	MetricSets  []string          `yaml:"metric-sets"`
+	metricSets  MetricSet         `yaml:"-"`
+	IntBrdNam   string            `yaml:"br-int-name" env:"OPENSTACK_NETWORK_EXPORTER_BR_INT_NAME"`
 }
 
 var c = conf{
-	HttpListen: ":1981",
-	HttpPath:   "/metrics",
-	OvsRundir:  "/run/openvswitch",
-	OvnRundir:  "/run/ovn",
-	OvsProcdir: "/proc",
-	LogLevel:   "notice",
-	users:      make(map[string]string),
-	IntBrdNam:  "br-int",
+	HttpListen:  ":1981",
+	HttpPath:    "/metrics",
+	OvsRundir:   "/run/openvswitch",
+	OvnRundir:   "/run/ovn",
+	OvsdbRundir: "/run/ovn",
+	OvsProcdir:  "/proc",
+	LogLevel:    "notice",
+	users:       make(map[string]string),
+	IntBrdNam:   "br-int",
 }
 
 func HttpListen() string           { return c.HttpListen }
@@ -92,6 +94,7 @@ func TlsCert() string              { return c.TlsCert }
 func TlsKey() string               { return c.TlsKey }
 func OvsRundir() string            { return c.OvsRundir }
 func OvnRundir() string            { return c.OvnRundir }
+func OvsdbRundir() string          { return c.OvsdbRundir }
 func OvsProcdir() string           { return c.OvsProcdir }
 func Collectors() []string         { return c.Collectors }
 func LogLevel() syslog.Priority    { return c.logLevel }

--- a/etc/openstack-network-exporter.yaml
+++ b/etc/openstack-network-exporter.yaml
@@ -76,6 +76,15 @@
 #
 #ovn-rundir: /run/ovn
 
+# The absolute path to the runtime directory of the ovsdb server. This folder
+# is expected to contain the ovsdb server unixctl socket like "ovnsb_db.ctl"
+# or "ovnnb_db.ctl".
+#
+# Env: OPENSTACK_NETWORK_EXPORTER_OVSDB_RUNDIR
+# Default: /run/ovn
+#
+#ovsdb-rundir: /run/ovn
+
 # The absolute path to the runtime directory of openvswitch. This folder is
 # expected to contain the ovsdb-server socket endpoint "db.sock", the
 # "ovs-vswitchd.pid" file and each bridge openflow management sockets


### PR DESCRIPTION
Add new ovsdbserver collector to expose OVN Raft cluster status metrics for monitoring database cluster health and performance.

The collector implements 14 metrics with ovn_raft_ prefix covering cluster state, server roles, log indices, connection counts, and leadership status. All metrics are labeled with database name, cluster UUID, and server UUID for comprehensive cluster monitoring.

Key features include automatic detection of OVN Southbound or Northbound database sockets (ovnsb_db.ctl vs ovnnb_db.ctl), configurable socket location via ovs-db-server-rundir setting, and robust parsing of cluster status output using regex patterns.

The collector is designed to be extensible for future OVSDB server metrics beyond Raft cluster monitoring, providing a foundation for additional database server instrumentation.

Configuration changes add OvsDbServerRundir field with default /tmp and environment variable OPENSTACK_NETWORK_EXPORTER_OVS_DB_SERVER_RUNDIR. The appctl package gains ovsDbServer daemon support with specialized socket detection logic.