### PR TITLE
observability: add sample prometheus rule alert definitions

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,99 @@
+# Prometheus rules for OVS metrics
+
+This directory contains [Prometheus alerting rule][alerts] files for
+metrics exposed by openstack-network-exporter (OVS/OVN). These files can be
+used directly with standalone Prometheus or combined with a CRD header for
+Kubernetes/RHOSO.
+
+[alerts]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+**Sample files:**
+
+- `sample_ovs_pmd_alerts.yaml` – OVS PMD alerts (lost upcalls, non-voluntary
+  context switches).
+- `sample_ovs_interface_alerts.yaml` – OVS interface alerts (Rx dropped,
+  Rx errors, Tx errors).
+- `sample_openstack_network_exporter_down.yaml` – Critical alert when the
+  openstack-network-exporter scrape target is down.
+
+## Kubernetes / RHOSO (PrometheusRule CRD)
+
+For Kubernetes or RHOSO deployments using the Prometheus Operator, prepend
+one of the following headers to the sample file content to create a complete
+PrometheusRule CRD manifest.
+
+### OpenStack / RHOSO (telemetry-operator + metric-storage)
+
+Use when your cluster runs Red Hat Observability (`monitoring.rhobs`):
+
+```yaml
+apiVersion: monitoring.rhobs/v1
+kind: PrometheusRule
+metadata:
+  name: CHANGEME   # e.g. openstack-observability-network-exporter-down
+  namespace: openstack
+  labels:
+    service: metricStorage
+spec:
+```
+
+### Vanilla Prometheus Operator
+
+Use when your cluster uses the upstream Prometheus Operator
+(`monitoring.coreos.com`):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: CHANGEME   # e.g. openstack-observability-network-exporter-down
+  namespace: openstack   # or the namespace your Prometheus watches
+  labels:
+    role: alert-rules    # must match your Prometheus spec.ruleSelector
+spec:
+```
+
+### Applying rules (Kubernetes / RHOSO)
+
+1. Create a full manifest: paste one of the headers above, then the contents
+   of the sample file.
+2. Apply in the namespace that your Prometheus's `ruleNamespaceSelector`
+   watches (e.g. `openstack` for RHOSO):
+
+   ```bash
+   oc apply -f your-complete-rule.yaml -n openstack
+   ```
+
+3. Verify (OpenStack/RHOSO):
+
+   ```bash
+   oc get prometheusrules.monitoring.rhobs -n openstack
+   ```
+
+## Standalone Prometheus (no Kubernetes)
+
+For a standalone Prometheus installation, use the sample files directly:
+
+1. **Add the rule files to `prometheus.yml`:**
+
+   ```yaml
+   # Alertmanager configuration
+   alerting:
+     alertmanagers:
+       - static_configs:
+           - targets: ['localhost:9093']
+
+   # Load rules once and periodically evaluate them according to the
+   # global 'evaluation_interval'.
+   rule_files:
+     - /path/to/openstack-network-exporter/observability/prometheus/rules/sample_ovs_pmd_alerts.yaml
+     - /path/to/openstack-network-exporter/observability/prometheus/rules/sample_ovs_interface_alerts.yaml
+     # - /path/to/openstack-network-exporter/observability/prometheus/rules/sample_openstack_network_exporter_down.yaml
+   ```
+
+2. **Reload Prometheus** to pick up the new rules:
+
+   ```bash
+   curl -X POST http://localhost:9090/-/reload
+   # or restart the Prometheus service
+   ```

--- a/rules/sample_openstack_network_exporter_down.yaml
+++ b/rules/sample_openstack_network_exporter_down.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Alert when openstack-network-exporter scrape target is down.
+# Uses for: 5m so brief outages (e.g. node reboot) are ignored.
+# For Kubernetes/RHOSO, prepend a CRD header from README.md.
+# For standalone Prometheus, use this file directly via rule_files in prometheus.yml.
+---
+groups:
+  - name: openstack-observability.openstack-network-exporter.status
+    rules:
+      - alert: OpenStackNetworkExporterDownCritical
+        expr: |
+          up{job=~"scrapeConfig/openstack/telemetry-openstack-network-exporter(-tls)?"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OpenStack network exporter down (critical)"
+          description: |
+            The openstack-network-exporter scrape target has been down for more than 5 minutes.
+            OVS/OVN metrics are not being collected.
+            Instance: {{ $labels.instance }}
+            Job: {{ $labels.job }}

--- a/rules/sample_ovs_interface_alerts.yaml
+++ b/rules/sample_ovs_interface_alerts.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# OVS interface error/drop alert rules. For Kubernetes/RHOSO, prepend a CRD header from README.md.
+# For standalone Prometheus, use this file directly via rule_files in prometheus.yml.
+#
+# Metrics: ovs_interface_rx_dropped, ovs_interface_rx_errors, ovs_interface_tx_errors
+# Labels: bridge, port, interface, type
+---
+groups:
+  - name: openstack-observability.ovs.interface
+    rules:
+      - alert: OVSInterfaceRxDroppedWarning
+        expr: |
+          (
+            increase(ovs_interface_rx_dropped[5m]) > 100
+          )
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "OVS interface Rx ring drops (warning)"
+          description: |
+            Interface {{ $labels.interface }} has more than 100 packets dropped in the last 5 minutes
+            because the Rx ring was full. Bridge: {{ $labels.bridge }}
+
+      - alert: OVSInterfaceRxErrorsCritical
+        expr: |
+          (
+            increase(ovs_interface_rx_errors[5m]) > 100
+          )
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OVS interface Rx errors (critical)"
+          description: |
+            Interface {{ $labels.interface }} has more than 100 invalid packets received in the last 5 minutes.
+            Bridge: {{ $labels.bridge }}
+
+      - alert: OVSInterfaceTxErrorsCritical
+        expr: |
+          (
+            increase(ovs_interface_tx_errors[5m]) > 100
+          )
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OVS interface Tx errors (critical)"
+          description: |
+            Interface {{ $labels.interface }} has more than 100 errors while transmitting packets in the last 5 minutes.
+            Bridge: {{ $labels.bridge }}

--- a/rules/sample_ovs_pmd_alerts.yaml
+++ b/rules/sample_ovs_pmd_alerts.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# OVS PMD alert rules. For Kubernetes/RHOSO, prepend a CRD header from README.md.
+# For standalone Prometheus, use this file directly via rule_files in prometheus.yml.
+#
+# Metrics: ovs_pmd_lost_upcalls, ovs_pmd_nonvol_context_switches (labels: numa, cpu)
+---
+groups:
+  - name: openstack-observability.ovs.pmd
+    rules:
+      - alert: OVSPMDLostUpcallsCritical
+        expr: |
+          increase(ovs_pmd_lost_upcalls[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OVS PMD lost upcalls (critical)"
+          description: |
+            PMD thread cpu {{ $labels.cpu }} (numa {{ $labels.numa }}) has lost upcalls
+            in the last 5 minutes. A lost upcall means the PMD dropped the upcall entirely:
+            no userspace handling, no flow install, no retry. This is real, unrecoverable
+            packet drop—not noise.
+
+      - alert: OVSPMDNonVoluntaryContextSwitchesHigh
+        expr: |
+          increase(ovs_pmd_nonvol_context_switches[5m]) > 200
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OVS PMD high non-voluntary context switches (critical)"
+          description: |
+            PMD thread cpu {{ $labels.cpu }} (numa {{ $labels.numa }}) has more than 200
+            non-voluntary context switches in the last 5 minutes. High context switching
+            indicates the PMD is being preempted; this can cause packet drops and degraded
+            datapath performance.


### PR DESCRIPTION
Add PrometheusRule alert examples based on metrics exposed by openstack-network-exporter.

Include README with CRD headers to be used in deployments.