### PR TITLE
  Add Dependabot and binary release workflow 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          GOOS=linux GOARCH=amd64 go build -trimpath \
+            -o openstack-network-exporter-linux-amd64 .
+          GOOS=linux GOARCH=arm64 go build -trimpath \
+            -o openstack-network-exporter-linux-arm64 .
+          sha256sum openstack-network-exporter-linux-* > checksums.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            openstack-network-exporter-linux-amd64
+            openstack-network-exporter-linux-arm64
+            checksums.txt
+          generate_release_notes: true


### PR DESCRIPTION
- Enable Dependabot (weekly) for Go modules and GitHub Actions to prevent silent dependency drift — the broken libovsdb v0.7.0 reference is a direct consequence of having no automated update process.   

- Add a release workflow that triggers on v* tags and publishes linux/amd64 and linux/arm64 binaries with a sha256 checksum file as GitHub release assets, for deployments that don't use a container runtime. 