### PR TITLE
ovsdb: migrate from ovn-org/libovsdb to ovn-kubernetes/libovsdb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,9 @@ go 1.21
 
 require (
 	github.com/go-logr/logr v1.4.1
-	github.com/ovn-org/libovsdb v0.7.0
+	github.com/ovn-kubernetes/libovsdb v0.8.0
 	github.com/prometheus/client_golang v1.20.5
+	github.com/skydive-project/goloxi v0.0.0-20190117172159-db2324197a3e
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,7 +29,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/skydive-project/goloxi v0.0.0-20190117172159-db2324197a3e // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/ovn-org/libovsdb v0.7.0 h1:owk3MHhaJ0gs0dWvTBtj7lPGEzbcyPrDYerEFqPXO/Y=
-github.com/ovn-org/libovsdb v0.7.0/go.mod h1:dJbxEaalQl83nn904K32FaMjlH/qOObZ0bj4ejQ78AI=
+github.com/ovn-kubernetes/libovsdb v0.8.0 h1:cWhqWb5rCiS3yTJ6VJ7s85cElE1NWWJ2XksPGLd5WII=
+github.com/ovn-kubernetes/libovsdb v0.8.0/go.mod h1:8nqWvM5pjHRbI5K6Uy/yuA5MdhCnGhNFH5fsSjZD8Rc=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=

--- a/ovsdb/ovs/gen.go
+++ b/ovsdb/ovs/gen.go
@@ -3,6 +3,6 @@
 
 package ovs
 
-import _ "github.com/ovn-org/libovsdb/modelgen"
+import _ "github.com/ovn-kubernetes/libovsdb/modelgen"
 
-//go:generate go run github.com/ovn-org/libovsdb/cmd/modelgen -o . -p ovs schema.json
+//go:generate go run github.com/ovn-kubernetes/libovsdb/cmd/modelgen -o . -p ovs schema.json

--- a/ovsdb/ovsdb.go
+++ b/ovsdb/ovsdb.go
@@ -11,9 +11,9 @@ import (
 	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
-	"github.com/ovn-org/libovsdb/client"
-	"github.com/ovn-org/libovsdb/model"
-	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
 
 var (


### PR DESCRIPTION
The github.com/ovn-org/libovsdb module was deprecated and the v0.7.0 tag was never pushed to the upstream repository, causing all builds to fail with "unknown revision v0.7.0".

The project has moved to github.com/ovn-kubernetes/libovsdb. Migrate to v0.8.0, the first release with the renamed module path, and update the two import sites in ovsdb/ovsdb.go and ovsdb/ovs/gen.go. The generated API (FullDatabaseModel, Schema) is unchanged.