### PR TITLE
ci: validate build against the product environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,31 @@ jobs:
       - uses: actions/checkout@v4
       - run: make
 
+  build-product:
+    name: Product build (ubi9/go-toolset:1.24, CGO, FIPS)
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi9/go-toolset:1.24
+      options: --user root
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-product-${{ hashFiles('go.sum') }}
+      - name: Download modules
+        run: go mod download
+      - name: Generate OVSDB models
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          CGO_ENABLED=1 GO111MODULE=on go generate ./...
+      - name: Build with product flags
+        run: |
+          CGO_ENABLED=1 GO111MODULE=on go build \
+            -trimpath -mod=readonly -tags=strictfipsruntime -a \
+            -o openstack-network-exporter .
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,23 @@ cert.pem key.pem:
 run: openstack-network-exporter cert.pem key.pem
 	OPENSTACK_NETWORK_EXPORTER_YAML=etc/dev.yaml ./$<
 
+# Closest public equivalent to openshift/golang-builder:rhel_9_golang_1.24
+# used in the CPaaS/Cachito product build.
+PRODUCT_BUILDER ?= registry.access.redhat.com/ubi9/go-toolset:1.24
+GOMODCACHE ?= $(shell go env GOMODCACHE)
+
+.PHONY: build-product
+build-product:
+	podman run --rm --user root \
+		-v $(CURDIR):/app:z \
+		-v $(GOMODCACHE):/go/pkg/mod:z,ro \
+		-w /app \
+		-e GOMODCACHE=/go/pkg/mod \
+		$(PRODUCT_BUILDER) bash -c \
+		'CGO_ENABLED=1 GO111MODULE=on go generate ./... && \
+		 CGO_ENABLED=1 GO111MODULE=on go build -trimpath -mod=readonly \
+		   -tags=strictfipsruntime -a -o openstack-network-exporter .'
+
 .PHONY: container
 container:
 	podman build -t ${IMG} .


### PR DESCRIPTION
Add a product build job to CI that runs inside
registry.access.redhat.com/ubi9/go-toolset:1.24, in order to line up with rhel 9.6 golang.

The job runs go generate and go build with the exact flags used in the product Dockerfile: CGO_ENABLED=1, -mod=readonly, -tags=strictfipsruntime.

Also add a build-product make target so developers can reproduce the same build locally without access to the internal build system.