### PR TITLE
config: fix reflect panic on environment variable overrides

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -120,7 +120,7 @@ func Parse() error {
 
 	// override with values from environment
 	typ := reflect.TypeOf(c)
-	val := reflect.ValueOf(c)
+	val := reflect.ValueOf(&c).Elem()
 	for i := 0; i < typ.NumField(); i++ {
 		fieldVal := val.Field(i)
 		fieldType := typ.Field(i)


### PR DESCRIPTION
reflect.ValueOf(c) returns a non-addressable copy of the struct, causing a panic when SetString() is called. Use a pointer to the original value instead.